### PR TITLE
Fixed version check & edited software name on warning message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ except ImportError:
 
 # check numpy version
 import numpy
-np_major, np_minor, np_release = [int(x) for x in numpy.version.short_version.split('.')]
+np_major, np_minor = [int(x) for x in numpy.version.short_version.split('.')[:2]]
 if np_major < 1 or (np_major == 1 and np_minor < 8):
-    raise ImportError('PowerFit requires NumPy version 1.8 or ' \
+    raise ImportError('DisVis requires NumPy version 1.8 or ' \
         'higher. You have version {:s}'.format(numpy.version.short_version))
 
 def main():


### PR DESCRIPTION
Fixed an error message on install when using a release candidate version of numpy (installed from pip):

``` bash
Traceback (most recent call last):
  File "setup.py", line 14, in <module>
    np_major, np_minor, np_release = [int(x) for x in numpy.version.short_version.split('.')]
ValueError: invalid literal for int() with base 10: '0rc1'
```
