### PR TITLE
Divide ligand's VDW radii by voxelspacing

### DIFF
--- a/disvis/disvis.py
+++ b/disvis/disvis.py
@@ -136,7 +136,7 @@ class DisVis(object):
         # Set ligand center to the origin of the grid and calculate the core
         # shape. The coordinates are wrapped around in the density.
         self._lgridcoor = (self.ligand.coor - self.ligand.center) / self.voxelspacing
-        radii = self.ligand.vdw_radius
+        radii = self.ligand.vdw_radius / self.voxelspacing
         self._lcore = np.zeros(self._shape, dtype=np.float64)
         dilate_points(self._lgridcoor, radii, self._lcore)
 


### PR DESCRIPTION
This commit fixes a bug in DisVis when using the voxel spacing option (i.e., -vs > 1). 
DisVis divides the vdw radii of the receptor by self.voxelspacing, but without this patch, it does not divide the vdw radii of the *ligand* by voxelspacing. 

The effect of this bug is positioning the ligand and receptor too far apart when voxelspacing > 1 is used, since the vdw radii in the 1A voxel spacing reference frame occupy a lot more effective space when the voxel spacing is increased to, say, 4A. 