### PR TITLE
Fix for Typo in main.py #20

### DIFF
--- a/disvis/main.py
+++ b/disvis/main.py
@@ -5,6 +5,7 @@ from os.path import join, abspath
 from sys import stdout, exit
 from time import time
 import multiprocessing as mp
+import Queue
 from argparse import ArgumentParser
 import logging
 
@@ -247,7 +248,7 @@ def mp_cpu_disvis(receptor, ligand, rotmat, weights, distance_restraints,
     # Check whether the queue is empty, this indicates failure to run on
     # multi-processor runs.
     if queue.empty():
-        raise mp.Queue.Empty
+        raise Queue.Empty
 
     write('Searching done. Combining results')
 


### PR DESCRIPTION
According to the information I found it is a missing `import Queue` statement, this should fix the issue.

<https://stackoverflow.com/questions/13941562/why-can-i-not-catch-a-queue-empty-exception-from-a-multiprocessing-queue>