### PR TITLE
Add `dump_args` helper function

### DIFF
--- a/disvis/helpers.py
+++ b/disvis/helpers.py
@@ -1,10 +1,12 @@
 import os
 import errno
+import copy
+import json
 try:
     import pyopencl as cl
 except ImportError:
     pass
-    
+
 
 def get_queue():
     try:
@@ -89,3 +91,13 @@ def parse_interaction_selection(fid, pdb1, pdb2):
 
 
     return pdb1_sel, pdb2_sel
+
+def dump_args(args):
+    """Dump the arguments to a `.json` file"""
+    _args = copy.deepcopy(args)
+    for key, value in vars(args).items():
+        if isinstance(value, file):
+            setattr(_args, key, value.name)
+
+    with open('args.json', 'w') as f:
+        json.dump(vars(_args), f, indent=4, sort_keys=True)

--- a/disvis/main.py
+++ b/disvis/main.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from disvis import DisVis, PDB, Volume
 from disvis.rotations import proportional_orientations, quat_to_rotmat
-from disvis.helpers import mkdir_p
+from disvis.helpers import mkdir_p, dump_args
 
 
 def parse_args():
@@ -347,6 +347,8 @@ def write(line):
 def main():
 
     args = parse_args()
+
+    dump_args(args)
 
     mkdir_p(args.directory)
     joiner = Joiner(args.directory)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if CYTHON:
 requirements = ["numpy",]
 
 setup(name="disvis",
-      version='2.0.0',
+      version='2.2.0',
       description=description,
       url="https://github.com/haddocking/disvis",
       author='Gydo C.P. van Zundert',


### PR DESCRIPTION
This PR adds a simple `dump_args` helper function that dumps the `argparse` object into a `args.json` file in the current working directory.